### PR TITLE
Update slack app path references to match WORKDIR /app -> /usr/src/app

### DIFF
--- a/workflows/slack/versions/0.0.1/images/send-message/Dockerfile
+++ b/workflows/slack/versions/0.0.1/images/send-message/Dockerfile
@@ -15,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-CMD ["node", "/app/index.js"]
+CMD ["node", "/usr/src/app/index.js"]

--- a/workflows/slack/versions/0.0.1/workflowTemplate.yaml
+++ b/workflows/slack/versions/0.0.1/workflowTemplate.yaml
@@ -38,7 +38,7 @@ spec:
         image: quay.io/codefreshplugins/argo-hub-workflows-slack-versions-0.0.1-images-send-message:main
         command:
           - node
-          - /app/index.js
+          - /usr/src/app/index.js
         env:
           - name: MODE
             value: '{{ inputs.parameters.MODE }}'


### PR DESCRIPTION
Signed-off-by: Jesse Antoszyk <jesse@antoszyk.com>

Running the container as is yields the following (similar output when running the workflow): 
```bash 
$ docker run -it -e MODE=simple -e SLACK_HOOK_URL='hook.url/secret' -e SLACK_TEXT='my cool text' quay.io/codefreshplugins/argo-hub-workflows-slack-versions-0.0.1-images-send-message:main 
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module '/app/index.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```