### PR TITLE
Add get-github-info which provides all the Classic pipeline vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 
-
+# macOS custom attributes file
+.DS_Store

--- a/workflows/github/CHANGELOG.md
+++ b/workflows/github/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.2 (8.12.2021)
+
+### get-github-info
+
+Parses the GitHub Event Payload (JSON) and output the most useful payload fields as artifact files.
+
 ## v0.0.1 (1.12.2021)
 
 ### commit-status

--- a/workflows/github/versions/0.0.2/README.md
+++ b/workflows/github/versions/0.0.2/README.md
@@ -1,0 +1,17 @@
+# Github
+
+## Summary
+
+A set of templates to perform operations against github
+
+## Templates
+
+1. [commit-status](https://github.com/codefresh-io/argo-hub/blob/main/workflows/github/versions/0.0.2/docs/commit-status.md)
+2. [create-pr](https://github.com/codefresh-io/argo-hub/blob/main/workflows/github/versions/0.0.2/docs/create-pr.md)
+3. [get-github-info](https://github.com/codefresh-io/argo-hub/blob/main/workflows/github/versions/0.0.2/docs/get-github-info.md)
+
+## Security
+
+Minimal required permissions
+
+[Full rbac permissions list](https://github.com/codefresh-io/argo-hub/blob/main/workflows/github/versions/0.0.2/rbac.yaml)

--- a/workflows/github/versions/0.0.2/docs/commit-status.md
+++ b/workflows/github/versions/0.0.2/docs/commit-status.md
@@ -1,0 +1,108 @@
+# commit-status
+
+## Summary
+Reports a commit status check.
+
+## Inputs/Outputs
+
+### Inputs
+GITHUB_TOKEN_SECRET (required) - K8s secret name that contains a key named `token` with github access token
+BUILD_BASE_URL (required) - Your argo workflow exposed instance url
+REPO_OWNER (required) - Repository Owner
+REPO_NAME (required) - Repository Name
+REVISION (required) - commit sha
+STATE (required) - one of the possible states
+CONTEXT (required) - context to report
+DESCRIPTION (required) - general description
+
+### Outputs
+no outputs
+
+## Examples
+
+### Report commit status at the beginning and end of a workflow
+```
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: github-commit-status-
+spec:
+  entrypoint: main
+  onExit: exit-handler
+  templates:
+    - name: main
+      dag:
+        tasks:
+        - name: report-commit-status-start
+          templateRef:
+            name: codefresh-marketplace.github.0.0.2
+            template: commit-status
+          arguments:
+            parameters:
+            - name: BUILD_BASE_URL
+              value: 'http://your.argo-workflow'
+            - name: REPO_OWNER
+              value: 'codefresh-io'
+            - name: REPO_NAME
+              value: 'argo-hub'
+            - name: REVISION
+              value: 'sha'
+            - name: STATE
+              value: 'pending'
+            - name: CONTEXT
+              value: 'name'
+            - name: DESCRIPTION
+              value: 'Workflow is running'
+            - name: GITHUB_TOKEN_SECRET
+              value: 'github-token'
+
+    - name: exit-handler
+        steps:
+          - - name: report-commits-status-failure
+              when: '{{workflow.status}} =~ "Failed|Error"'
+              templateRef:
+                name: codefresh-marketplace.github.0.0.2
+                template: commit-status
+              arguments:
+                parameters:
+                  - name: BUILD_BASE_URL
+                    value: 'http://your.argo-workflow'
+                  - name: REPO_OWNER
+                    value: 'codefresh-io'
+                  - name: REPO_NAME
+                    value: 'argo-hub'
+                  - name: REVISION
+                    value: 'sha'
+                  - name: STATE
+                    value: 'failure'
+                  - name: CONTEXT
+                    value: 'name'
+                  - name: DESCRIPTION
+                    value: 'Workflow failed'
+                  - name: GITHUB_TOKEN_SECRET
+                    value: 'github-token'
+    
+          - - name: report-commits-status-success
+              when: '{{workflow.status}} == Succeeded'
+              templateRef:
+                name: codefresh-marketplace.github.0.0.2
+                template: commit-status
+              arguments:
+                parameters:
+                  - name: BUILD_BASE_URL
+                    value: 'http://your.argo-workflow'
+                  - name: REPO_OWNER
+                    value: 'codefresh-io'
+                  - name: REPO_NAME
+                    value: 'argo-hub'
+                  - name: REVISION
+                    value: 'sha'
+                  - name: STATE
+                    value: 'success'
+                  - name: CONTEXT
+                    value: 'name'
+                  - name: DESCRIPTION
+                    value: 'Workflow succeeded'
+                  - name: GITHUB_TOKEN_SECRET
+                    value: 'github-token'
+```

--- a/workflows/github/versions/0.0.2/docs/create-pr.md
+++ b/workflows/github/versions/0.0.2/docs/create-pr.md
@@ -1,0 +1,26 @@
+# create-pr
+
+## Summary
+Creates a pull request.
+
+## Inputs/Outputs
+
+### Inputs
+#### Artifacts
+repo (required) - an artifact that contains the required repository
+
+#### Parameters
+GITHUB_TOKEN_SECRET (required) - K8s secret name that contains a key named `token` with github access token
+BRANCH (required) - branch name
+MESSAGE (required) - pr message
+PR_TEMPLATE (required) - pull request template
+
+### Outputs
+no outputs
+
+## Examples
+
+### Create a pull request from a specific branch back to main
+```
+
+```

--- a/workflows/github/versions/0.0.2/docs/get-github-info.md
+++ b/workflows/github/versions/0.0.2/docs/get-github-info.md
@@ -1,0 +1,122 @@
+# get-github-info
+
+## Summary
+Parse the GitHub Event Payload (JSON). Output the most useful payload fields as artifact files, which can be mapped into global workflow outputs, and then consumed by any subsequent templates. The list of fields closely matches the pipeline variables that were previously  established in Codefresh's [Classic platform](https://codefresh.io/docs/docs/codefresh-yaml/variables).
+
+## Inputs/Outputs
+
+### Inputs
+GITHUB_JSON (required) - GitHub event payload (JSON) string from a GitHub EventSource + Sensor.
+
+### Outputs
+CF_REPO_OWNER - Repository owner.
+CF_REPO_NAME - Repository name.
+CF_BRANCH - Branch name (or Tag depending on the payload json) of the Git repository of the main pipeline, at the time of execution.
+CF_BASE_BRANCH - The base branch used during creation of Tag.
+CF_PULL_REQUEST_ACTION - The pull request action.
+CF_PULL_REQUEST_TARGET - The pull request target branch.
+CF_PULL_REQUEST_NUMBER - The pull request number.
+CF_PULL_REQUEST_ID - The pull request id.
+CF_PULL_REQUEST_LABELS - The labels of pull request.
+CF_COMMIT_AUTHOR - Commit author.
+CF_COMMIT_USERNAME - Commit username.
+CF_COMMIT_EMAIL - Commit email.
+CF_COMMIT_URL - Commit url.
+CF_COMMIT_MESSAGE - Commit message of the Git repository revision, at the time of execution.
+CF_REVISION - Revision of the Git repository of the main pipeline, at the time of execution.
+CF_SHORT_REVISION - The abbreviated 7-character revision hash, as used in Git.
+CF_RELEASE_NAME - GitHub release title.
+CF_RELEASE_TAG - Git tag version.
+CF_RELEASE_ID - Internal ID for this release.
+CF_PRERELEASE_FLAG - "true" if the release is marked as non-production ready, "false" if it is ready for production.
+CF_PULL_REQUEST_MERGED - "true" if the pull request was merged to base branch.
+CF_PULL_REQUEST_HEAD_BRANCH - The head branch of the PR (the branch that we want to merge to master).
+CF_PULL_REQUEST_MERGED_COMMIT_SHA - The commit SHA on the base branch after the pull request was merged (in most cases it will be master).
+CF_PULL_REQUEST_HEAD_COMMIT_SHA - The commit SHA on the head branch (the branch that we want to push).
+
+## Examples
+
+### Store key fields from a GitHub event payload as global workflow outputs, and consume them from a subsequent template.
+```
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: example-github-sensor
+spec:
+  eventBusName: codefresh-eventbus
+  template:
+    serviceAccountName: argo
+  dependencies:
+    - name: github-dep
+      eventSourceName: github
+      eventName: push
+  triggers:
+    - template:
+        name: example-github
+        argoWorkflow:
+          version: v1alpha1
+          group: argoproj.io
+          resource: workflows
+          operation: submit
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: example-github-
+              spec:
+                workflowTemplateRef:
+                  name: example-steps
+                serviceAccountName: codefresh-marketplace.github.0.0.2
+                arguments:
+                  parameters:
+                    - name: GITHUB_JSON
+          parameters:
+            - dest: spec.arguments.parameters.0.value
+              src:
+                dependencyName: github-dep
+                dataKey: body
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: example-steps
+spec:
+  arguments:
+    parameters:
+      - name: GITHUB_JSON
+  entrypoint: example-steps
+  templates:
+    - name: example-steps
+      steps:
+      # 1. Store GitHub info as global workflow outputs
+      - - name: get-github-info
+          templateRef:
+            name: argo-hub.github.0.0.2
+            template: get-github-info
+          arguments:
+            parameters:
+            - name: GITHUB_JSON
+              value: "{{workflow.parameters.GITHUB_JSON}}"
+      # 2. Consume some global workflow outputs in a subsequent step
+      - - name: log-info
+          template: log-info
+          arguments:
+            parameters:
+            - name: INFO
+              value: "{{workflow.outputs.parameters.CF_REPO_OWNER}}/{{workflow.outputs.parameters.CF_REPO_NAME}}"
+    - name: log-info
+      inputs:
+        parameters:
+          - name: INFO
+      script:
+        image: alpine:latest
+        command: ["/bin/sh"]
+        env:
+          - name: INFO
+            value: "{{ inputs.parameters.INFO }}"
+        source: |
+          set -e
+          echo ${INFO}
+```

--- a/workflows/github/versions/0.0.2/images/commit-status/Dockerfile
+++ b/workflows/github/versions/0.0.2/images/commit-status/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:14.18.1-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+# If you are building your code for production
+# RUN npm ci --only=production
+
+# Bundle app source
+COPY . .
+
+CMD [ "node", "index.js" ]

--- a/workflows/github/versions/0.0.2/images/commit-status/index.js
+++ b/workflows/github/versions/0.0.2/images/commit-status/index.js
@@ -1,0 +1,44 @@
+const { Octokit } = require("@octokit/rest");
+
+let octokit, owner, repo, revision, targetURL, description, context, state;
+
+const setGitStatus = async () => {
+    try {
+        await octokit.repos
+            .createCommitStatus({
+                owner: owner,
+                repo: repo,
+                sha: revision,
+                state,
+                target_url: targetURL,
+                description,
+                context,
+            });
+    } catch (err) {
+        throw new Error(`Failed to report status to github with error: ${JSON.stringify(err ? err.message : '')} for repo: ${repo} revision: ${revision}`);
+    }
+}
+
+const flow = async () => {
+    await setGitStatus();
+}
+
+const main = async () => {
+    octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+    owner = process.env.CF_REPO_OWNER;
+    repo = process.env.CF_REPO_NAME;
+    revision = process.env.CF_REVISION;
+    targetURL = `${process.env.CF_BUILD_BASE_URL || 'https://g.codefresh.io/build/'}${process.env.CF_BUILD_ID}`;
+    description = process.env.DESCRIPTION;
+    context = process.env.CONTEXT;
+    state = process.env.STATE;
+
+    try {
+        await flow();
+    } catch (err) {
+        console.error(`Unexpected error: ${err.stack}. \nExiting.`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/workflows/github/versions/0.0.2/images/commit-status/package.json
+++ b/workflows/github/versions/0.0.2/images/commit-status/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "github-commit-status",
+  "version": "1.0.0",
+  "main": "diff.js",
+  "license": "MIT",
+  "dependencies": {
+    "@octokit/rest": "^18.10.0"
+  }
+}

--- a/workflows/github/versions/0.0.2/images/create-pr/Dockerfile
+++ b/workflows/github/versions/0.0.2/images/create-pr/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:alpine
+
+RUN apk update
+RUN apk add git curl
+RUN go get github.com/github/hub
+
+ENTRYPOINT hub

--- a/workflows/github/versions/0.0.2/images/get-github-info/Dockerfile
+++ b/workflows/github/versions/0.0.2/images/get-github-info/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.9-slim
+
+COPY parse_github_payload.py /

--- a/workflows/github/versions/0.0.2/images/get-github-info/parse_github_payload.py
+++ b/workflows/github/versions/0.0.2/images/get-github-info/parse_github_payload.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# This script and Dockerfile are for use in an Argo Workflows template, to parse the GitHub Event Payload (JSON).
+# Output the most useful payload fields as artifact files, which can be mapped into global workflow outputs, and then
+# consumed by any subsequent templates. The list of fields closely matches the pipeline variables that were previously 
+# established in Codefresh's Classic platform: https://codefresh.io/docs/docs/codefresh-yaml/variables
+
+import os
+import json
+
+INPUT_PAYLOAD_JSON_ENV_VAR = "GITHUB_JSON"
+OUTPUT_DIR = "/tmp/gitvars/"
+
+def main():
+    # Read json from env var into a dictionary
+    payload_json = os.getenv(INPUT_PAYLOAD_JSON_ENV_VAR)
+    # print(payload_json)
+    payload_dict = json.loads(payload_json)
+
+    # Create output dir
+    os.makedirs(OUTPUT_DIR, exist_ok = True)
+
+    # Generate output files from payload
+    output_common_git_vars(payload_dict)
+    output_common_pr_vars(payload_dict)
+    output_github_release_vars(payload_dict)
+    output_github_pr_vars(payload_dict)
+
+
+def output_common_git_vars(payload_dict):
+    # Duplicated from Classic: https://codefresh.io/docs/docs/codefresh-yaml/variables/#system-provided-variables
+    write_var_file("CF_REPO_OWNER", payload_dict["repository"]["owner"]["name"])
+    write_var_file("CF_REPO_NAME", payload_dict["repository"]["name"])
+    ref = payload_dict["ref"]
+    write_var_file("CF_BRANCH", ref.replace("refs/heads/", ""))
+    write_var_file("CF_BASE_BRANCH", payload_dict["base_ref"])
+    write_var_file("CF_COMMIT_AUTHOR", payload_dict["head_commit"]["author"]["name"])
+    write_var_file("CF_COMMIT_USERNAME", payload_dict["head_commit"]["author"]["username"])
+    write_var_file("CF_COMMIT_EMAIL", payload_dict["head_commit"]["author"]["email"])
+    write_var_file("CF_COMMIT_URL", payload_dict["head_commit"]["url"])
+    write_var_file("CF_COMMIT_MESSAGE", payload_dict["head_commit"]["message"])
+    sha = payload_dict["after"]
+    write_var_file("CF_REVISION", sha)
+    write_var_file("CF_SHORT_REVISION", sha[0:7])
+
+
+def output_common_pr_vars(payload_dict):
+    # Duplicated from Classic: https://codefresh.io/docs/docs/codefresh-yaml/variables/#system-provided-variables
+    if payload_dict["X-GitHub-Event"] == "pull_request":
+        print("Not a PR event - PR outputs will be empty")
+        write_var_file("CF_PULL_REQUEST_ACTION", payload_dict["action"])
+        write_var_file("CF_PULL_REQUEST_TARGET", payload_dict["pull_request"]["base"]["ref"])
+        write_var_file("CF_PULL_REQUEST_NUMBER", payload_dict["number"])
+        write_var_file("CF_PULL_REQUEST_ID", payload_dict["pull_request"]["id"])
+        write_var_file("CF_PULL_REQUEST_LABELS", payload_dict["pull_request"]["labels"])
+    else:
+        write_var_file("CF_PULL_REQUEST_ACTION", "")
+        write_var_file("CF_PULL_REQUEST_TARGET", "")
+        write_var_file("CF_PULL_REQUEST_NUMBER", "")
+        write_var_file("CF_PULL_REQUEST_ID", "")
+        write_var_file("CF_PULL_REQUEST_LABELS", "")
+
+
+def output_github_release_vars(payload_dict):
+    # Duplicated from Classic: https://codefresh.io/docs/docs/codefresh-yaml/variables/#github-release-variables
+    if payload_dict["X-GitHub-Event"] == "release":
+        write_var_file("CF_RELEASE_NAME", payload_dict["release"]["name"])
+        write_var_file("CF_RELEASE_TAG", payload_dict["release"]["tag_name"])
+        write_var_file("CF_RELEASE_ID", payload_dict["release"]["id"])
+        write_var_file("CF_PRERELEASE_FLAG", payload_dict["release"]["prerelease"])
+    else:
+        write_var_file("CF_RELEASE_NAME", "")
+        write_var_file("CF_RELEASE_TAG", "")
+        write_var_file("CF_RELEASE_ID", "")
+        write_var_file("CF_PRERELEASE_FLAG", "")
+
+
+def output_github_pr_vars(payload_dict):
+    # Duplicated from Classic: https://codefresh.io/docs/docs/codefresh-yaml/variables/#github-pull-request-variables
+    if payload_dict["X-GitHub-Event"] == "pull_request":
+        write_var_file("CF_PULL_REQUEST_MERGED", payload_dict["pull_request"]["merged"])
+        write_var_file("CF_PULL_REQUEST_HEAD_BRANCH", payload_dict["pull_request"]["head"]["ref"])
+        write_var_file("CF_PULL_REQUEST_MERGED_COMMIT_SHA", payload_dict["pull_request"]["merge_commit_sha"])
+        write_var_file("CF_PULL_REQUEST_HEAD_COMMIT_SHA", payload_dict["pull_request"]["head"]["sha"])
+    else:
+        write_var_file("CF_PULL_REQUEST_MERGED", "")
+        write_var_file("CF_PULL_REQUEST_HEAD_BRANCH", "")
+        write_var_file("CF_PULL_REQUEST_MERGED_COMMIT_SHA", "")
+        write_var_file("CF_PULL_REQUEST_HEAD_COMMIT_SHA", "")
+
+
+def write_var_file(name, value):
+    # Make sure value isn't null
+    if not value:
+        value = ""
+    # Cast array and boolean values to string
+    value_str = str(value)
+    # Write the value to output file
+    with open(OUTPUT_DIR + name, 'w') as file:
+        file.write(value_str)
+    print(name + "=" + value_str)
+
+    
+if __name__ == "__main__":
+    main()

--- a/workflows/github/versions/0.0.2/rbac.yaml
+++ b/workflows/github/versions/0.0.2/rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: codefresh-marketplace.github.0.0.2
+  annotations:
+    codefresh-marketplace/version: '0.0.2'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: codefresh-marketplace.github.0.0.2
+  annotations:
+    codefresh-marketplace/version: '0.0.2'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: codefresh-marketplace.github.0.0.2
+  annotations:
+    codefresh-marketplace/version: '0.0.2'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: codefresh-marketplace.github.0.0.2
+subjects:
+  - kind: ServiceAccount
+    name: codefresh-marketplace.github.0.0.2
+

--- a/workflows/github/versions/0.0.2/workflowTemplate.yaml
+++ b/workflows/github/versions/0.0.2/workflowTemplate.yaml
@@ -1,0 +1,217 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: codefresh-marketplace.github.0.0.2
+  annotations:
+    codefresh-marketplace/version: '0.0.2'
+    codefresh-marketplace/description: 'Execute operations against Github'
+    codefresh-marketplace/license: 'MIT'
+    codefresh-marketplace/owner_name: 'Itai Gendler'
+    codefresh-marketplace/owner_email: 'itai@codefresh.io'
+    codefresh-marketplace/owner_avatar: 'https://avatars.githubusercontent.com/u/10414627?s=120&v=4'
+    codefresh-marketplace/owner_url: 'https://github.com/itai-codefresh'
+    codefresh-marketplace/categories: 'git'
+    codefresh-marketplace/icon_url: "https://cdn.jsdelivr.net/gh/codefresh-io/argo-hub@main/workflows/github/assets/icon.svg"
+    codefresh-marketplace/icon_background: "#f4f4f4"
+spec:
+  templates:
+    - name: commit-status
+      metadata:
+        annotations:
+          codefresh-marketplace-template/description: 'Report a commit status check'
+          codefresh-marketplace-template/icon_url: "https://cdn.jsdelivr.net/gh/codefresh-io/argo-hub@main/workflows/github/assets/icon.svg"
+          codefresh-marketplace-template/icon_background: "#f4f4f4"
+      retryStrategy:
+        limit: "10"
+        retryPolicy: "Always"
+        backoff:
+          duration: "5s"
+      inputs:
+        parameters:
+          - name: BUILD_BASE_URL
+          - name: REPO_OWNER
+          - name: REPO_NAME
+          - name: REVISION
+          - name: STATE
+          - name: CONTEXT
+          - name: DESCRIPTION
+          - name: GITHUB_TOKEN_SECRET
+      container:
+        name: main
+        imagePullPolicy: Always
+        image: quay.io/codefreshplugins/argo-hub-workflows-github-versions-0.0.2-images-commit-status:main
+        command:
+          - node
+          - index.js
+        env:
+          - name: CF_BUILD_ID
+            value: '{{ workflow.name }}'
+          - name: CF_BUILD_BASE_URL
+            value: '{{ inputs.parameters.BUILD_BASE_URL }}'
+          - name: CF_REPO_OWNER
+            value: '{{ inputs.parameters.REPO_OWNER }}'
+          - name: CF_REPO_NAME
+            value: '{{ inputs.parameters.REPO_NAME }}'
+          - name: CF_REVISION
+            value: '{{ inputs.parameters.REVISION }}'
+          - name: STATE
+            value: '{{ inputs.parameters.STATE }}'
+          - name: CONTEXT
+            value: '{{ inputs.parameters.CONTEXT }}'
+          - name: DESCRIPTION
+            value: '{{ inputs.parameters.DESCRIPTION }}'
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: '{{ inputs.parameters.GITHUB_TOKEN_SECRET }}'
+                key: token
+
+    - name: create-pr
+      metadata:
+        annotations:
+          codefresh-marketplace-template/description: 'Create a pull request'
+          codefresh-marketplace-template/icon_url: "https://cdn.jsdelivr.net/gh/codefresh-io/argo-hub@main/workflows/github/assets/icon.svg"
+          codefresh-marketplace-template/icon_background: "#f4f4f4"
+      inputs:
+        artifacts:
+          - name: repo
+            path: /code
+        parameters:
+          - name: BRANCH
+          - name: MESSAGE
+          - name: PR_TEMPLATE
+          - name: GITHUB_TOKEN_SECRET
+      script:
+        workingDir: '{{ inputs.artifacts.repo.path }}'
+        imagePullPolicy: Always
+        image: quay.io/codefreshplugins/argo-hub-workflows-github-versions-0.0.2-images-create-pr:main
+        command: [sh]
+        source: |
+          git checkout {{inputs.parameters.BRANCH}}
+          export EXISTING_PR=$(hub pr list -b main -h {{ inputs.parameters.BRANCH }} -s open -f %I)
+          if [ -z $EXISTING_PR ] ; then hub pull-request --base main --head {{ inputs.parameters.BRANCH }} -m {{ inputs.parameters.MESSAGE }} --no-edit -m "$(curl {{ inputs.parameters.PR_TEMPLATE }} )" ; else echo "Pull request already exists"; fi;
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: '{{ inputs.parameters.GITHUB_TOKEN_SECRET }}'
+                key: token
+
+    - name: get-github-info
+      metadata:
+        annotations:
+          codefresh-marketplace-template/description: 'Parses the GitHub Event Payload (JSON) and output the most useful payload fields as artifact files.'
+          codefresh-marketplace-template/icon_url: "https://cdn.jsdelivr.net/gh/codefresh-io/argo-hub@main/workflows/github/assets/icon.svg"
+          codefresh-marketplace-template/icon_background: "#f4f4f4"
+          codefresh-marketplace/owner_name: 'Ted Spinks'
+          codefresh-marketplace/owner_email: 'ted.spinks@codefresh.io'
+          codefresh-marketplace/owner_avatar: 'https://avatars.githubusercontent.com/u/12577557?s=120&v=4'
+          codefresh-marketplace/owner_url: 'https://github.com/TedSpinks'
+      inputs:
+        parameters:
+        - name: GITHUB_JSON
+      container:
+        image: quay.io/codefreshplugins/argo-hub-workflows-github-versions-0.0.2-images-get-github-info:main
+        command: ["python3"]
+        args: ["/parse_github_payload.py"]
+        env:
+        - name: GITHUB_JSON
+          value: '{{ inputs.parameters.GITHUB_JSON }}'
+      outputs:
+        parameters:
+        - name: CF_REPO_OWNER
+          valueFrom:
+            path: /tmp/gitvars/CF_REPO_OWNER
+          globalName: CF_REPO_OWNER
+        - name: CF_REPO_NAME
+          valueFrom:
+            path: /tmp/gitvars/CF_REPO_NAME
+          globalName: CF_REPO_NAME
+        - name: CF_BRANCH
+          valueFrom:
+            path: /tmp/gitvars/CF_BRANCH
+          globalName: CF_BRANCH
+        - name: CF_BASE_BRANCH
+          valueFrom:
+            path: /tmp/gitvars/CF_BASE_BRANCH
+          globalName: CF_BASE_BRANCH
+        - name: CF_COMMIT_AUTHOR
+          valueFrom:
+            path: /tmp/gitvars/CF_COMMIT_AUTHOR
+          globalName: CF_COMMIT_AUTHOR
+        - name: CF_COMMIT_USERNAME
+          valueFrom:
+            path: /tmp/gitvars/CF_COMMIT_USERNAME
+          globalName: CF_COMMIT_USERNAME
+        - name: CF_COMMIT_EMAIL
+          valueFrom:
+            path: /tmp/gitvars/CF_COMMIT_EMAIL
+          globalName: CF_COMMIT_EMAIL
+        - name: CF_COMMIT_URL
+          valueFrom:
+            path: /tmp/gitvars/CF_COMMIT_URL
+          globalName: CF_COMMIT_URL
+        - name: CF_COMMIT_MESSAGE
+          valueFrom:
+            path: /tmp/gitvars/CF_COMMIT_MESSAGE
+          globalName: CF_COMMIT_MESSAGE
+        - name: CF_REVISION
+          valueFrom:
+            path: /tmp/gitvars/CF_REVISION
+          globalName: CF_REVISION
+        - name: CF_SHORT_REVISION
+          valueFrom:
+            path: /tmp/gitvars/CF_SHORT_REVISION
+          globalName: CF_SHORT_REVISION
+        - name: CF_PULL_REQUEST_ACTION
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_ACTION
+          globalName: CF_PULL_REQUEST_ACTION
+        - name: CF_PULL_REQUEST_TARGET
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_TARGET
+          globalName: CF_PULL_REQUEST_TARGET
+        - name: CF_PULL_REQUEST_NUMBER
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_NUMBER
+          globalName: CF_PULL_REQUEST_NUMBER
+        - name: CF_PULL_REQUEST_ID
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_ID
+          globalName: CF_PULL_REQUEST_ID
+        - name: CF_PULL_REQUEST_LABELS
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_LABELS
+          globalName: CF_PULL_REQUEST_LABELS
+        - name: CF_RELEASE_NAME
+          valueFrom:
+            path: /tmp/gitvars/CF_RELEASE_NAME
+          globalName: CF_RELEASE_NAME
+        - name: CF_RELEASE_TAG
+          valueFrom:
+            path: /tmp/gitvars/CF_RELEASE_TAG
+          globalName: CF_RELEASE_TAG
+        - name: CF_RELEASE_ID
+          valueFrom:
+            path: /tmp/gitvars/CF_RELEASE_ID
+          globalName: CF_RELEASE_ID
+        - name: CF_PRERELEASE_FLAG
+          valueFrom:
+            path: /tmp/gitvars/CF_PRERELEASE_FLAG
+          globalName: CF_PRERELEASE_FLAG
+        - name: CF_PULL_REQUEST_MERGED
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_MERGED
+          globalName: CF_PULL_REQUEST_MERGED
+        - name: CF_PULL_REQUEST_HEAD_BRANCH
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_HEAD_BRANCH
+          globalName: CF_PULL_REQUEST_HEAD_BRANCH
+        - name: CF_PULL_REQUEST_MERGED_COMMIT_SHA
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_MERGED_COMMIT_SHA
+          globalName: CF_PULL_REQUEST_MERGED_COMMIT_SHA
+        - name: CF_PULL_REQUEST_HEAD_COMMIT_SHA
+          valueFrom:
+            path: /tmp/gitvars/CF_PULL_REQUEST_HEAD_COMMIT_SHA
+          globalName: CF_PULL_REQUEST_HEAD_COMMIT_SHA


### PR DESCRIPTION
Added a template, get-github-info, which provides all of the Classic Codefresh pipeline vars as global workflow outputs. They can then be consumed by any subsequent templates.