### PR TITLE
Update argo-hub/workflows/argocd/versions/0.0.1/README.md

### DIFF
--- a/workflows/argocd/versions/0.0.1/README.md
+++ b/workflows/argocd/versions/0.0.1/README.md
@@ -12,19 +12,19 @@ A set of operations that can be performed against ArgoCD apps
 
 1. [action-restart](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/action-restart.md)
 
-1. [action-resume](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/action-resume)
+1. [action-resume](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/action-resume.md)
 
-1. [action-retry](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/action-retry)
+1. [action-retry](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/action-retry.md)
 
-1. [history](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/history)
+1. [history](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/history.md)
 
-1. [list](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/list)
+1. [list](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/list.md)
 
-1. [rollback](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/rollback)
+1. [rollback](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/rollback.md)
 
-1. [sync](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/sync)
+1. [sync](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/sync.md)
 
-1. [wait](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/wait)
+1. [wait](https://github.com/codefresh-io/argo-hub/blob/main/workflows/argocd/versions/0.0.1/docs/wait.md)
 
 ## Security
 


### PR DESCRIPTION
Fixed some broken links that were missing the ".md" file extension.