### PR TITLE
Fix: ArgoCD RBAC typo & default inputs references

### DIFF
--- a/workflows/argocd/versions/0.0.1/rbac.yaml
+++ b/workflows/argocd/versions/0.0.1/rbac.yaml
@@ -29,7 +29,7 @@ rules:
       - watch
   - apiGroups:
       - ""
-    resource:
+    resources:
       - secrets
     verbs:
       - get

--- a/workflows/argocd/versions/0.0.1/workflowTemplate.yaml
+++ b/workflows/argocd/versions/0.0.1/workflowTemplate.yaml
@@ -83,31 +83,31 @@ spec:
       parameters:
       # The app to run the argo command against
       - name: app
-        value: ""
+        default: ""
       # Flags specific to the command you are running (i.e. -l "my-label")
       - name: flags
-        value: ""
+        default: ""
       # The url for communicating with the ArgoCD server
       # i.e. argocd-server.<namespace>.svc.cluster.local
       - name: serverUrl
-        value: ""
       # Global command line options to pass to the ArgoCD CLI
       - name: opts
-        value: ""
+        default: ""
       # The Kubernetes secret with the token to communicate with ArgoCD
       - name: tokenSecret
-        value: "argocd-token"
+        default: "argocd-token"
       # The key name in the Kubernetes secret with the token to communicate with ArgoCD
       - name: tokenSecretKey
-        value: "token"
+        default: "token"
       # The Kubernetes 'Kind' to use with argo app actions command
       - name: appKind
-        value: "Rollout"
+        default: "Rollout"
       # The ID to roll back to if performing a rollback
       - name: rollbackId
-        value: ""
+        default: ""
       # Set xtrace or not (echo the command before running it). Valid options are -o (xtrace on) and +o (xtrace off). default is -o
       - name: xtraceOption
+        default: "-o"
 
   # Wait for an app status
   - name: wait

--- a/workflows/argocd/versions/0.0.1/workflowTemplate.yaml
+++ b/workflows/argocd/versions/0.0.1/workflowTemplate.yaml
@@ -81,14 +81,32 @@ spec:
     # Parameters users can set/override
     inputs: &inputs
       parameters:
+      # The app to run the argo command against
       - name: app
+        value: ""
+      # Flags specific to the command you are running (i.e. -l "my-label")
       - name: flags
+        value: ""
+      # The url for communicating with the ArgoCD server
+      # i.e. argocd-server.<namespace>.svc.cluster.local
       - name: serverUrl
+        value: ""
+      # Global command line options to pass to the ArgoCD CLI
       - name: opts
+        value: ""
+      # The Kubernetes secret with the token to communicate with ArgoCD
       - name: tokenSecret
+        value: "argocd-token"
+      # The key name in the Kubernetes secret with the token to communicate with ArgoCD
       - name: tokenSecretKey
-      - name: appKind # used for app 'actions' commands
+        value: "token"
+      # The Kubernetes 'Kind' to use with argo app actions command
+      - name: appKind
+        value: "Rollout"
+      # The ID to roll back to if performing a rollback
       - name: rollbackId
+        value: ""
+      # Set xtrace or not (echo the command before running it). Valid options are -o (xtrace on) and +o (xtrace off). default is -o
       - name: xtraceOption
 
   # Wait for an app status


### PR DESCRIPTION
Fix for RBAC (resource -> resources). 
Make input defaults work when referencing as `templateRef` by moving them into the workflow template. Previously these would only use the defaults when referencing this as a `workflowTemplateRef`