### PR TITLE
Fix: Update slack app path to match WORKDIR app installed in

### DIFF
--- a/workflows/slack/versions/0.0.1/images/send-message/Dockerfile
+++ b/workflows/slack/versions/0.0.1/images/send-message/Dockerfile
@@ -15,4 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-CMD ["node", "/app/index.js"]
+CMD ["node", "/usr/src/app/index.js"]

--- a/workflows/slack/versions/0.0.1/workflowTemplate.yaml
+++ b/workflows/slack/versions/0.0.1/workflowTemplate.yaml
@@ -39,7 +39,7 @@ spec:
         image: quay.io/codefreshplugins/argo-hub-workflows-slack-versions-0.0.1-images-send-message:main
         command:
           - node
-          - /app/index.js
+          - /usr/src/app/index.js
         env:
           - name: MODE
             value: '{{ inputs.parameters.MODE }}'


### PR DESCRIPTION
[Dockerfile `WORKDIR`](https://github.com/codefresh-io/argo-hub/blob/main/workflows/slack/versions/0.0.1/images/send-message/Dockerfile#L4) is `/usr/src/app/` but [Dockerfile `CMD`](https://github.com/codefresh-io/argo-hub/blob/main/workflows/slack/versions/0.0.1/images/send-message/Dockerfile#L18) and [Workflow `command`](https://github.com/codefresh-io/argo-hub/blob/main/workflows/slack/versions/0.0.1/workflowTemplate.yaml#L42) reference `/app/` instead. This updates CMD/command references to `/usr/src/app/`

Running the container as is yields the following (similar output when running the workflow):

$ docker run -it -e MODE=simple -e SLACK_HOOK_URL='hook.url/secret' -e SLACK_TEXT='my cool text' quay.io/codefreshplugins/argo-hub-workflows-slack-versions-0.0.1-images-send-message:main 
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module '/app/index.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}