### PR TITLE
CR-15353: test with returned message

### DIFF
--- a/workflows/slack/versions/0.0.2/images/post-to-channel/lib/slack.py
+++ b/workflows/slack/versions/0.0.2/images/post-to-channel/lib/slack.py
@@ -42,7 +42,6 @@ def main():
 
     try:
         response = client.chat_postMessage(channel=channel, text=message)
-        assert response["message"]["text"] == message
     except SlackApiError as e:
         # You will get a SlackApiError if "ok" is False
         assert e.response["ok"] is False


### PR DESCRIPTION
in some cases, the returned msg is slightly different that the one sent (like URL, interpolation, ...) has been fixed in the classic implementation already